### PR TITLE
Add contact webform API, got missed in the migration

### DIFF
--- a/ui/src/app/api/contact/route.ts
+++ b/ui/src/app/api/contact/route.ts
@@ -1,0 +1,111 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(request: NextRequest) {
+  let name, email, organization, subject, message
+
+  try {
+    const data = await request.json()
+    name = data.name
+    email = data.email
+    organization = data.organization
+    subject = data.subject
+    message = data.message
+
+    // Validate required fields
+    if (!name || !email || !subject || !message) {
+      console.error('Missing required fields:', { name: !!name, email: !!email, subject: !!subject, message: !!message })
+      return NextResponse.json(
+        { error: 'Missing required fields' },
+        { status: 400 }
+      )
+    }
+
+    console.log('Processing contact form submission...')
+
+    // Create formatted email content
+    const emailContent = {
+      to: 'tendertalesinc@gmail.com',
+      subject: `[Tender Tales Contact] ${subject}`,
+      html: `
+        <h2>New Contact Form Submission</h2>
+        <p><strong>From:</strong> ${name} (${email})</p>
+        <p><strong>Organization:</strong> ${organization || 'Not specified'}</p>
+        <p><strong>Subject:</strong> ${subject}</p>
+        <div>
+          <strong>Message:</strong><br/>
+          <p>${message.replace(/\n/g, '<br/>')}</p>
+        </div>
+        <hr>
+        <p><small>This message was sent via the Tender Tales contact form.</small></p>
+      `,
+      text: `
+New Contact Form Submission
+
+From: ${name} (${email})
+Organization: ${organization || 'Not specified'}
+Subject: ${subject}
+
+Message:
+${message}
+
+---
+This message was sent via the Tender Tales contact form.
+      `.trim()
+    }
+
+    console.log('Sending email via webhook...')
+
+    // Use EmailJS or similar service webhook
+    const response = await fetch('https://api.web3forms.com/submit', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+      },
+      body: JSON.stringify({
+        access_key: process.env.WEB3FORMS_ACCESS_KEY || 'demo', // You'll need to get this
+        name: name,
+        email: email,
+        subject: `[Tender Tales Contact] ${subject}`,
+        message: `
+Organization: ${organization || 'Not specified'}
+
+${message}
+
+---
+Contact Email: ${email}
+        `.trim(),
+        to: 'tendertalesinc@gmail.com'
+      })
+    })
+
+    if (!response.ok) {
+      throw new Error(`Webhook failed: ${response.status}`)
+    }
+
+    const result = await response.json()
+    console.log('Email sent successfully via webhook:', result)
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('Error sending email via webhook:', {
+      message: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined
+    })
+
+    // Fallback: Log the contact form submission
+    console.log('CONTACT FORM SUBMISSION (MANUAL PROCESSING NEEDED):', {
+      name,
+      email,
+      organization,
+      subject,
+      message,
+      timestamp: new Date().toISOString()
+    })
+
+    return NextResponse.json(
+      { error: 'Failed to send email via webhook' },
+      { status: 500 }
+    )
+  }
+}


### PR DESCRIPTION
This pull request adds a new API endpoint to handle contact form submissions in the application. The endpoint validates input, formats the submission data, and sends it via a third-party webhook (Web3Forms). If the webhook fails, the submission is logged for manual processing.

Key additions:

**Contact Form Submission Endpoint:**

* Added a `POST` handler in `ui/src/app/api/contact/route.ts` to process contact form submissions, including validation of required fields (`name`, `email`, `subject`, `message`).
* Formats the submission into both HTML and plain text email content for consistent email delivery.
* Integrates with the Web3Forms webhook to send the contact form data to a designated email address, using an access key from environment variables.
* Implements error handling: if the webhook fails, logs the submission details for manual follow-up and returns an appropriate error response.